### PR TITLE
:memo: add link to the original spoofing attack paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
 
                     <div class="advanced-list-element color-border german">
                         <div class="advanced-element-header">
-                            <img src="Images/Icons/Languages/de.svg" class="advanced-header-logo" id="flag">
+                            <img src="images/icons/languages/de.svg" class="advanced-header-logo" id="flag">
                             <div class="advanced-header-content">
                                 <div class="advanced-title"> German </div>
                                 <div class="advanced-detail"> CEFR Level: <b>B2</b> </div>

--- a/papers.html
+++ b/papers.html
@@ -42,9 +42,9 @@
                     <p class="authors"> <a href="https://scholar.google.com/citations?user=DUI-bncAAAAJ&hl=en">Oleksandr Kuznetsov</a>, <a href="https://scholar.google.com/citations?user=WL-8aoAAAAAJ&hl=en">Dmytro Zakharov</a>, <a href="https://scholar.google.com/citations?user=Vgi8nAcAAAAJ&hl=en">Emanuele Frontoni</a> </p>
                     <p class="journal"> Published in Multimedia Tools and Applications (Springer) </p>
                     <div class="paper-links">
-                        <a href="https://www.researchsquare.com/article/rs-2913502/v1" class="paper-link">[Preprint]</a>
                         <a href="https://doi.org/10.1007/s11042-023-17714-7" class="paper-link">[Journal Paper]</a>
                         <a href="https://doi.org/10.1109/PICST57299.2022.10238643" class="paper-link">[Conference Paper]</a>
+                        <a href="https://www.researchsquare.com/article/rs-2913502/v1" class="paper-link">[Preprint]</a>
                         <a href="https://github.com/ZamDimon/Binary-Encoder" class="paper-link">[GitHub]</a>
                     </div>
                 </div>
@@ -56,6 +56,7 @@
                     <p class="authors"> <a href="https://scholar.google.com/citations?user=DUI-bncAAAAJ&hl=en">Oleksandr Kuznetsov</a>, <a href="https://scholar.google.com/citations?user=WL-8aoAAAAAJ&hl=en">Dmytro Zakharov</a>, <a href="https://scholar.google.com/citations?user=Vgi8nAcAAAAJ&hl=en">Emanuele Frontoni</a>, Andrea Maranesi, Serhii Bohucharskyi </p>
                     <p class="journal"> Published in CEUR Proceedings </p>
                     <div class="paper-links">
+                        <a href="https://ceur-ws.org/Vol-3608/#paper19" class="paper-link">[Paper]</a>
                         <a href="https://arxiv.org/abs/2401.16232" class="paper-link">[Preprint]</a>
                         <a href="https://paperswithcode.com/paper/cross-database-liveness-detection-insights" class="paper-link">[paperswithcode]</a>
                         <a href="https://github.com/ZamDimon/liveness-detection" class="paper-link">[GitHub]</a>


### PR DESCRIPTION
# 🔥 Hotfix

Germany paper is broken on the website, so we have fixed this issue.

... and also add the URL to the original paper _"Cross-Database Liveness Detection: Insights from Comparative Biometric Analysis ."_